### PR TITLE
Add int pointer type for data_types

### DIFF
--- a/04_memory_and_error_handling/01_challenge/autograder/rename_main.cpp
+++ b/04_memory_and_error_handling/01_challenge/autograder/rename_main.cpp
@@ -23,7 +23,7 @@ void extract_variables(std::string& content) {
     bool in_main_function = false;
 
     std::vector<std::string> data_types = {
-        "int", "float", "double", "char", "long", "short", "bool", "std::string"
+        "int", "float", "double", "char", "long", "short", "bool", "std::string", "int*"
     };
 
     while (std::getline(stream, line)) {


### PR DESCRIPTION
With the current test code for the 04-01 challenge, the test does not work.
This is because the `extern int* p;`  in `test.cpp` should refer the global variable in `dummy_main.cpp`, but with the current `rename_main.cpp`, `int* p` is produced inside of main function scope of `dummy_main.cpp`.
In this PR, I added `int*`in data_types and make it global variable .

Reference: Error message with the current test
```bash
-- Configuring done (0.7s)                                                                                         
-- Generating done (0.0s)                                                                                          
-- Build files have been written to: /home/koki-ota/ws/src/cpp-01-ja/04_memory_and_error_handling/01_challenge/auto
grader/build                                                                                                       
[ 18%] Built target gtest                                                                                          
[ 36%] Built target gtest_main                                                                                     
[ 45%] Building CXX object CMakeFiles/Tests.dir/gen/dummy_main.cpp.o                                               
[ 54%] Linking CXX executable Tests                                                                                
/usr/bin/ld: CMakeFiles/Tests.dir/home/koki-ota/ws/src/cpp-01-ja/04_memory_and_error_handling/01_challenge/tests/te
sts.cpp.o: warning: relocation against `p' in read-only section `.text'                                            
/usr/bin/ld: CMakeFiles/Tests.dir/home/koki-ota/ws/src/cpp-01-ja/04_memory_and_error_handling/01_challenge/tests/tests.cpp.o: in function `Test_Address_Test::TestBody()':
tests.cpp:(.text+0x187): undefined reference to `p'
/usr/bin/ld: CMakeFiles/Tests.dir/home/koki-ota/ws/src/cpp-01-ja/04_memory_and_error_handling/01_challenge/tests/tests.cpp.o: in function `Test_PrintAddressAndValue_Test::TestBody()':
tests.cpp:(.text+0x2f0): undefined reference to `p'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/Tests.dir/build.make:115: Tests] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/Tests.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
./autograder/run: line 3: ./autograder/build/Tests: No such file or directory
```